### PR TITLE
Fix cross-device temp file rename

### DIFF
--- a/src/fs.ts
+++ b/src/fs.ts
@@ -6,6 +6,7 @@ import {
   open,
   readFileSync,
   rename,
+  copyFile,
   unlink,
   writeFile
 } from "fs"
@@ -21,6 +22,7 @@ const $exists = promisify(exists)
 , $close = promisify(close)
 , $mkdir = promisify(mkdir)
 , $rename = promisify(rename)
+, $copy = promisify(copyFile)
 , tempDir = join(tmpdir(), schema.title)
 
 export {
@@ -31,6 +33,7 @@ export {
   $write,
   $close,
   $rename,
+  $copy,
   tempFileName,
   tempDir
 }

--- a/src/rewrite.ts
+++ b/src/rewrite.ts
@@ -5,8 +5,10 @@ import {
   $exists,
   $open,
   $rename,
+  $copy,
   $write,
-  tempFileName
+  $unlink,
+  tempFileName,
 } from "./fs"
 
 export = rewrite
@@ -57,5 +59,10 @@ async function rewrite(filename: string, lines: string[], eol: string, checkMode
     }`)
 
   await $close(fd)
-  await $rename(tempFile, filename)
+  try {
+    await $rename(tempFile, filename)
+  } catch (error) {
+    await $copy(tempFile, filename)
+    await $unlink(tempFile)
+  }
 }


### PR DESCRIPTION
Fix fail on trying to rename temp file if `tmp` folder located on a different disk partition.

```
EXDEV: cross-device link not permitted, rename '/tmp/postcss-d-ts/v0mqwjlonpg' -> '/home/user/projects/project-name/client-ts/src/ui/document-view/DocumentView.less.d.ts'
```